### PR TITLE
Ensure DB pair ordering

### DIFF
--- a/api/db/sqldb.py
+++ b/api/db/sqldb.py
@@ -500,7 +500,7 @@ class SqlQuery(SqlDB):
             return default.result(msg=e, loglevel="warning")
 
     @timed
-    def pair_trade_volumes_usd(self, volumes: Dict) -> list:
+    def pair_trade_vols_usd(self, volumes: Dict) -> list:
         """
         Returns volume traded of a pair between two timestamps.
         If no timestamp is given, returns volume for last 24hrs.
@@ -546,7 +546,7 @@ class SqlQuery(SqlDB):
             )
             return default.result(
                 data=volumes,
-                msg=f"pair_trade_volumes_usd complete [US${total_trade_vol_usd}]",
+                msg=f"pair_trade_vols_usd complete [US${total_trade_vol_usd}]",
                 loglevel="query",
                 ignore_until=0,
             )

--- a/api/lib/cache_calc.py
+++ b/api/lib/cache_calc.py
@@ -5,7 +5,16 @@ from lib.cmc import CmcAPI
 from lib.pair import Pair
 from util.cron import cron
 from util.logger import logger, timed
-from util.transform import clean, derive, merge, template, convert, deplatform, sortdata, invert
+from util.transform import (
+    clean,
+    derive,
+    merge,
+    template,
+    convert,
+    deplatform,
+    sortdata,
+    invert,
+)
 import db.sqldb as db
 import lib.prices
 import util.defaults as default
@@ -489,7 +498,7 @@ class CacheCalc:
                         logger.warning(f"Inverting non standard pair {depair}")
                         depair = invert.pair(depair)
                     depair_orderbook = book["orderbooks"][depair]
-                    
+
                     if depaired:
                         v_data = depair_orderbook["ALL"]
                         data.update(template.markets_ticker(depair, v_data))
@@ -534,7 +543,9 @@ class CacheCalc:
                     sorted_pairs = list(
                         set(
                             [
-                                sortdata.pair_by_market_cap(i, gecko_source=self.gecko_source)
+                                sortdata.pair_by_market_cap(
+                                    i, gecko_source=self.gecko_source
+                                )
                                 for i in book["orderbooks"].keys()
                             ]
                         )
@@ -570,15 +581,17 @@ class CacheCalc:
                                         )
                                     }
                                 )
-                                '''
+                                """
                                 if depair != sortdata.pair_by_market_cap(depair, gecko_source=self.gecko_source):
                                     logger.info(f"Ticker for {depair} updated (non-standard)")
                                 else:
                                     logger.info(f"Ticker for {depair} updated")
-                                '''
+                                """
                                 ok += 1
                         else:
-                            logger.warning(f"Ticker failed [not in extended orderbook] for {depair} and {invert.pair(depair)} (standard is {sortdata.pair_by_market_cap(depair, gecko_source=self.gecko_source)})")
+                            logger.warning(
+                                f"Ticker failed [not in extended orderbook] for {depair} and {invert.pair(depair)} (standard is {sortdata.pair_by_market_cap(depair, gecko_source=self.gecko_source)})"
+                            )
                             not_ok += 1
                     logger.calc(f"{ok}/{ok + not_ok} pairs added to tickers cache")
                 memcache.set_tickers(resp)

--- a/api/lib/cache_calc.py
+++ b/api/lib/cache_calc.py
@@ -477,26 +477,8 @@ class CacheCalc:
                 base, quote = derive.base_quote(pair_str=depair)
                 if deplatform.coin(coin) in [None, base, quote]:
                     if depaired:
-                        for variant in book["orderbooks"][depair]:
-                            if variant != "ALL":
-                                v = variant.replace("-segwit", "")
-                                v_data = book["orderbooks"][depair][variant]
-                                if v not in data:
-                                    data.update(template.markets_ticker(v, v_data))
-                                else:
-                                    data[v]["quote_volume"] += Decimal(
-                                        v_data["quote_liquidity_coins"]
-                                    )
-                                    data[v]["base_volume"] += Decimal(
-                                        v_data["base_liquidity_coins"]
-                                    )
-                                    if (
-                                        v_data["newest_price_time"]
-                                        > data[v]["last_price_time"]
-                                    ):
-                                        data[v]["last_price"] = Decimal(
-                                            v_data["newest_price_24hr"]
-                                        )
+                        v_data = book["orderbooks"][depair]["ALL"]
+                        data.update(template.markets_ticker(depair, v_data))
                     else:
                         for variant in book["orderbooks"][depair]:
                             if variant != "ALL":

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -35,3 +35,4 @@ pytest-flake8 = "^1.1.1"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+package-mode = false

--- a/api/routes/cache_loop.py
+++ b/api/routes/cache_loop.py
@@ -43,7 +43,7 @@ def start_seednode_stats():  # pragma: no cover
 @router.on_event("startup")
 @repeat_every(seconds=900)
 @timed
-def import_seednode_stats():  # pragma: no cover
+def import_seed_stats():  # pragma: no cover
     """Imports seednode stats from MM2.db into PgSQL"""
     try:
         start_time = int(cron.now_utc()) - 86400

--- a/api/routes/cache_loop.py
+++ b/api/routes/cache_loop.py
@@ -369,7 +369,7 @@ def adex_24hr():
 
 # TICKERS
 @router.on_event("startup")
-@repeat_every(seconds=300)
+@repeat_every(seconds=120)
 @timed
 def pair_tickers():
     if memcache.get("testing") is None:

--- a/api/routes/markets.py
+++ b/api/routes/markets.py
@@ -338,7 +338,7 @@ def volumes_ticker(coin="KMD", days_in_past=1, trade_type: TradeType = TradeType
             start_time = int(day_ts)
             end_time = int(day_ts) + 86400
             volumes = query.coin_trade_volumes(start_time=start_time, end_time=end_time)
-            data = query.coin_trade_volumes_usd(volumes)
+            data = query.coin_trade_vols_usd(volumes)
             volumes_dict[d_str] = template.volumes_ticker()
             for variant in variants:
                 if decoin in data["volumes"]:

--- a/api/routes/new_db.py
+++ b/api/routes/new_db.py
@@ -338,13 +338,13 @@ def swap_uuids(
 
 
 @router.get(
-    "/coin_trade_volumes_usd",
+    "/coin_trade_vols_usd",
     description="Trade volumes for each coin over the selected time period.",
     responses={406: {"model": ErrorMessage}},
     response_model=CoinTradeVolumes,
     status_code=200,
 )
-def coin_trade_volumes_usd(
+def coin_trade_vols_usd(
     start_time: int = 0,
     end_time: int = 0,
     pubkey: str | None = None,
@@ -361,7 +361,7 @@ def coin_trade_volumes_usd(
             start_time=start_time,
             end_time=end_time,
         )
-        return query.coin_trade_volumes_usd(volumes=volumes)
+        return query.coin_trade_vols_usd(volumes=volumes)
     except Exception as e:
         err = {"error": f"{e}"}
         logger.warning(err)

--- a/api/routes/new_db.py
+++ b/api/routes/new_db.py
@@ -375,7 +375,7 @@ def coin_trade_volumes_usd(
     response_model=PairTradeVolumes,
     status_code=200,
 )
-def pair_trade_volumes_usd(
+def pair_trade_vols_usd(
     start_time: int = 0,
     end_time: int = 0,
     pubkey: str | None = None,
@@ -397,7 +397,7 @@ def pair_trade_volumes_usd(
             coin=coin,
             gui=gui,
         )
-        return query.pair_trade_volumes_usd(volumes=volumes)
+        return query.pair_trade_vols_usd(volumes=volumes)
     except Exception as e:
         err = {"error": f"{e}"}
         logger.warning(err)

--- a/api/routes/new_db.py
+++ b/api/routes/new_db.py
@@ -26,6 +26,16 @@ cache = Cache()
 
 
 @router.get(
+    "/fix_swap_pairs",
+    description=f"Pairs traded last {GENERIC_PAIRS_DAYS} days. Ordered by mcap.",
+    responses={406: {"model": ErrorMessage}},
+    status_code=200,
+)
+def fix_swap_pairs():
+    db.SqlSource().fix_swap_pairs()
+
+
+@router.get(
     "/get_pairs",
     description=f"Pairs traded last {GENERIC_PAIRS_DAYS} days. Ordered by mcap.",
     responses={406: {"model": ErrorMessage}},

--- a/api/routes/stats_xyz.py
+++ b/api/routes/stats_xyz.py
@@ -320,7 +320,7 @@ def volumes_ticker(coin="KMD", days_in_past=1, trade_type: TradeType = TradeType
         start_time = int(day_ts)
         end_time = int(day_ts) + 86400
         volumes = query.coin_trade_volumes(start_time=start_time, end_time=end_time)
-        data = query.coin_trade_volumes_usd(volumes)
+        data = query.coin_trade_vols_usd(volumes)
         volumes_dict[d_str] = 0
         if decoin in data["volumes"]:
             volumes_dict[d_str] = data["volumes"][decoin]["ALL"]["total_volume"]

--- a/api/stats/seednodes.py
+++ b/api/stats/seednodes.py
@@ -444,7 +444,7 @@ def migrate_sqlite_to_pgsql(ts):
             update_seednode_version_stats_row(row_data)
 
 
-def import_seednode_stats():
+def import_seed_stats():
     resp = requests.get("http://stats.kmd.io/api/source/seednode_version_stats/").json()
 
     for i in resp["results"]:
@@ -533,7 +533,7 @@ if __name__ == "__main__":
 
         # import data from other server
         elif sys.argv[1] == "import":
-            import_seednode_stats()
+            import_seed_stats()
 
         else:
             print(

--- a/api/tests/test_db.py
+++ b/api/tests/test_db.py
@@ -174,14 +174,14 @@ def test_get_swaps_for_coin(setup_swaps_db_data):
     assert len(r) == 4
 
 
-def test_coin_trade_volumes_usd(setup_swaps_db_data):
+def test_coin_trade_vols_usd(setup_swaps_db_data):
     DB = setup_swaps_db_data
     volumes = DB.coin_trade_volumes(
         start_time=int(cron.now_utc()) - 86400,
         end_time=int(cron.now_utc()),
     )
 
-    r = DB.coin_trade_volumes_usd(volumes)
+    r = DB.coin_trade_vols_usd(volumes)
     logger.info(r)
     logger.info(r.keys())
     logger.info(r["volumes"].keys())

--- a/api/util/files.py
+++ b/api/util/files.py
@@ -9,10 +9,7 @@ import util.validate as validate
 
 
 class Files:
-    def __init__(self, **kwargs):
-        self.kwargs = kwargs
-        self.options = []
-        default.params(self, self.kwargs, self.options)
+    def __init__(self):
         if os.getenv("IS_TESTING") == "True" == "True":
             folder = f"{API_ROOT_PATH}/tests/fixtures"
             self.foo = f"{folder}/foo.json"

--- a/api/util/memcache.py
+++ b/api/util/memcache.py
@@ -263,15 +263,6 @@ def get_adex_fortnite():  # pragma: no cover
 # return data
 
 """
-def set_tickers(data):  # pragma: no cover
-    update("generic_tickers", data, 3600)
-
-
-def get_tickers():  # pragma: no cover
-    data = get("generic_tickers")
-    return data
-
-
 def set_tickers_14d(data):  # pragma: no cover
     update("generic_tickers_14d", data, 3600)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - 127.0.0.1:7068:7068
     depends_on:
       - pgsqldb
-      - mm2_8762
+      - komodefi_8762
       - memcached
     logging:
       driver: "json-file"
@@ -82,7 +82,7 @@ services:
     env_file:
       - ./api/.env
     depends_on:
-      - mm2_8762
+      - komodefi_8762
     ports:
       - "127.0.0.1:5432:5432"
     logging:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,8 +30,8 @@ services:
         soft: 65535
         hard: 65535
 
-  mm2_8762:
-    container_name: mm2_8762
+  komodefi_8762:
+    container_name: komodefi_8762
     env_file:
       - ./mm2_8762/.env
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   defi_stats:
     container_name: api

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+echo "Installing apt deps..."
+sudo apt update
+sudo apt install postgresql postgresql-contrib build-essential python-dev python3-dev python3-psycopg2 libpq-dev libmysqlclient-dev default-libmysqlclient-dev pkg-config
+
 echo "Setup Python 3.10..."
 sudo apt update && sudo apt upgrade -y
 sudo apt install software-properties-common python3-apt jq -y
@@ -9,11 +13,12 @@ sudo apt install python3.10 python3.10-distutils -y
 sudo ln -sf /usr/bin/python3.10 /usr/bin/python3
 curl -sS https://bootstrap.pypa.io/get-pip.py | python3
 
+echo "Getting coins..."
 wget https://raw.githubusercontent.com/KomodoPlatform/coins/master/coins
 cp coins $(pwd)/mm2/coins
 cp coins $(pwd)/mm2_8762/coins
 
-
+echo "Setup mm2..."
 rpc_password="$(openssl rand -hex 20)-E"
 passphrase=$(openssl rand -hex 128)
 contents=$(jq '.rpc_password = "'${rpc_password}'"' $(pwd)/mm2_8762/MM2.template.json) && echo -E "${contents}" > $(pwd)/mm2_8762/MM2.json


### PR DESCRIPTION
Pair standardisation is based on marketcap where available, otherwise alphabetically. 
e.g. `LOWMC_HIGHMC` and `AAA_BBB`

Where the coins in a pair have a similar marketcap, this was resulting in some pair flipping in the database as two coins battled for mcap supremacy. 

To mitigate this, the mcap values for comparison have been generalised to 2 significant figures, so the flippening will only occur with a significant change in marketcap.

When this occurs, the database will automatically adjust existing database data to conform to the new pair standard.