### PR TITLE
Resource load mitigations

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -23,6 +23,10 @@ API_HOST='0.0.0.0'
 API_PORT=7068
 API_HOST='127.0.0.1'
 POETRY_VERSION='1.6.1'
+
+# GitHub Releases (required for /api/v3/dex_version)
+GH_USER='your_github_username'
+GH_TOKEN='github_pat_or_token_with_repo_scope'
 ```
 - A maintained MM2.db file, ideally sourced from a long running AtomicDEX-API seed node to ensure all data is included. This is periodically sourced via rsync with `./update_MM2.db` (assuming ssh key access). This should be added to cron to check for updates every minute. E.g. `* * * * * /home/admin/defi_stats/update_MM2_db.sh`
 

--- a/api/lib/cache.py
+++ b/api/lib/cache.py
@@ -170,24 +170,24 @@ class CacheItem:
     @property
     def cache_expiry(self):
         expiry_limits = {
-            "adex_24hr": 5,
-            "adex_weekly": 5,
-            "adex_fortnite": 10,
-            "adex_alltime": 15,
+            "adex_24hr": 15,
+            "adex_weekly": 15,
+            "adex_fortnite": 30,
+            "adex_alltime": 90,
             "coins": 1440,
             "coins_config": 1440,
             "coin_volumes_alltime": 1440,
-            "pairs_last_traded": 5,
+            "pairs_last_traded": 15,
             "gecko_source": 15,
-            "markets_summary": 5,
+            "markets_summary": 15,
             "fixer_rates": 15,
             "pair_volumes_24hr": 15,
             "pair_volumes_14d": 15,
             "pair_volumes_alltime": 15,
             "coin_volumes_24hr": 15,
-            "pairs_orderbook_extended": 15,
-            "gecko_pairs": 5,
-            "tickers": 5,
+            "pairs_orderbook_extended": 30,
+            "gecko_pairs": 15,
+            "tickers": 15,
         }
         if self.name in expiry_limits:
             return expiry_limits[self.name]

--- a/api/lib/cache_calc.py
+++ b/api/lib/cache_calc.py
@@ -189,7 +189,7 @@ class CacheCalc:
         return self._pairs_orderbook_extended_cache
 
     @timed
-    def pairs_orderbook_extended(self, pairs_days: int = 30, refresh: bool = False):
+    def pairs_orderbook_extended(self, pairs_days: int = 21, refresh: bool = False):
         try:
             if not self._acquire_batch_lock():
                 logger.loop("[orderbook-batch] skipped: batch already running")

--- a/api/lib/dex_version.py
+++ b/api/lib/dex_version.py
@@ -100,3 +100,4 @@ class DexVersionService:
             return refreshed["data"]
         return None
 
+

--- a/api/lib/dex_version.py
+++ b/api/lib/dex_version.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+import os
+from typing import Dict, Optional
+
+import requests
+
+from util.cron import cron
+from util.logger import logger
+import util.memcache as memcache
+
+
+class GitHubReleasesClient:
+    def __init__(self, owner: str, repo: str) -> None:
+        self.owner = owner
+        self.repo = repo
+        self.base_url = f"https://api.github.com/repos/{owner}/{repo}"
+        self.session = requests.Session()
+        self._configure_auth()
+
+    def _configure_auth(self):
+        user = os.getenv("GH_USER")
+        token = os.getenv("GH_TOKEN")
+        if user and token:
+            self.session.auth = (user, token)
+
+    def get_latest_release(self) -> Optional[Dict]:
+        url = f"{self.base_url}/releases/latest"
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        try:
+            resp = self.session.get(url, headers=headers, timeout=10)
+            resp.raise_for_status()
+        except requests.RequestException as exc:  # pragma: no cover - network failure
+            logger.warning(f"Failed to fetch latest release from GitHub: {exc}")
+            return None
+        return resp.json()
+
+
+class DexVersionService:
+    CHANGELOG_URL = "https://github.com/GLEECBTC/gleec-wallet/blob/main/CHANGELOG.md"
+    OWNER = "GLEECBTC"
+    REPO = "gleec-wallet"
+
+    def __init__(self, client: GitHubReleasesClient | None = None) -> None:
+        self.client = client or GitHubReleasesClient(self.OWNER, self.REPO)
+
+    def _normalize_tag(self, tag_name: str) -> str:
+        if tag_name.lower().startswith("v"):
+            return tag_name[1:]
+        return tag_name
+
+    def _status_for_version(self, version: str) -> str:
+        try:
+            parts = [int(p) for p in version.split(".")]
+            patch = parts[2] if len(parts) > 2 else 0
+            if patch == 0:
+                return "required"
+        except Exception:
+            logger.warning(f"Unable to derive patch info from version '{version}'")
+        return "recommended"
+
+    def _build_payload(self, version: str, download_url: str) -> Dict:
+        data = {
+            "status": self._status_for_version(version),
+            "new_version": version,
+            "changelog": self.CHANGELOG_URL,
+            "download_url": download_url,
+        }
+        return {"last_synced": int(cron.now_utc()), "data": data}
+
+    def refresh(self) -> Optional[Dict]:
+        release = self.client.get_latest_release()
+        if not release:
+            return None
+        tag_name = release.get("tag_name")
+        html_url = release.get("html_url")
+        if not tag_name:
+            logger.warning("GitHub release missing tag_name")
+            return None
+        normalized = self._normalize_tag(tag_name)
+        download_url = html_url or f"https://github.com/{self.OWNER}/{self.REPO}/releases/tag/{tag_name}"
+        payload = self._build_payload(normalized, download_url)
+        memcache.set_dex_version(payload)
+        return payload
+
+    def get_cached_payload(self) -> Optional[Dict]:
+        cached = memcache.get_dex_version()
+        if cached and isinstance(cached, dict) and "data" in cached:
+            return cached
+        return None
+
+    def get_version_info(self) -> Optional[Dict]:
+        cached = self.get_cached_payload()
+        if cached:
+            return cached["data"]
+        refreshed = self.refresh()
+        if refreshed:
+            return refreshed["data"]
+        return None
+

--- a/api/lib/pair.py
+++ b/api/lib/pair.py
@@ -379,6 +379,7 @@ class Pair:  # pragma: no cover
                         {variant: template.orderbook_extended(variant)}
                     )
                     variant_cache_name = f"orderbook_{variant}"
+                    cache_exists = memcache.get(variant_cache_name) is not None
                     base, quote = derive.base_quote(variant)
                     variant_orderbook = dex.get_orderbook(
                         base=base,
@@ -390,6 +391,17 @@ class Pair:  # pragma: no cover
                         depth=depth,
                         refresh=refresh,
                     )
+                    if not refresh and not cache_exists:
+                        dex.get_orderbook(
+                            base=base,
+                            quote=quote,
+                            coins_config=self.coins_config,
+                            gecko_source=self.gecko_source,
+                            pair_prices_24hr_cache=self.pair_prices_24hr_cache,
+                            variant_cache_name=variant_cache_name,
+                            depth=depth,
+                            refresh=True,
+                        )
                     if variant_orderbook is not None:
                         combo_orderbook[variant] = variant_orderbook
                         ignore_until = 3

--- a/api/main.py
+++ b/api/main.py
@@ -30,6 +30,7 @@ from routes import (
     stats_api,
     new_db,
     stats_xyz,
+    dex,
 )
 from lib.cache import Cache, CacheItem
 from models.generic import ErrorMessage, HealthCheck
@@ -164,6 +165,15 @@ app.include_router(
     cmc.router,
     prefix="/api/v3/cmc",
     tags=["Coin Market Cap"],
+    dependencies=[],
+    responses={418: {"description": "I'm a teapot"}},
+)
+
+
+app.include_router(
+    dex.router,
+    prefix="/api/v3",
+    tags=["Dex"],
     dependencies=[],
     responses={418: {"description": "I'm a teapot"}},
 )

--- a/api/models/dex.py
+++ b/api/models/dex.py
@@ -7,3 +7,4 @@ class DexVersionResponse(BaseModel):
     changelog: str
     download_url: str
 
+

--- a/api/models/dex.py
+++ b/api/models/dex.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel
+
+
+class DexVersionResponse(BaseModel):
+    status: str
+    new_version: str
+    changelog: str
+    download_url: str
+

--- a/api/routes/cache_loop.py
+++ b/api/routes/cache_loop.py
@@ -202,7 +202,7 @@ def coins():  # pragma: no cover
 
 # VOLUMES CACHE
 @router.on_event("startup")
-@repeat_every(seconds=330)
+@repeat_every(seconds=1800)
 @timed
 def get_coin_volumes_alltime():
     if memcache.get("testing") is None:
@@ -228,7 +228,7 @@ def gecko_data():  # pragma: no cover
 
 
 @router.on_event("startup")
-@repeat_every(seconds=360)
+@repeat_every(seconds=1800)
 @timed
 def gecko_pairs():  # pragma: no cover
     if memcache.get("testing") is None:
@@ -339,7 +339,7 @@ def import_dbs():
 
 
 @router.on_event("startup")
-@repeat_every(seconds=320)
+@repeat_every(seconds=3600)
 @timed
 def adex_alltime():
     if memcache.get("testing") is None:

--- a/api/routes/cache_loop.py
+++ b/api/routes/cache_loop.py
@@ -11,10 +11,12 @@ import util.memcache as memcache
 from lib.cache import Cache, CacheItem, reset_cache_files
 from lib.cache_calc import CacheCalc
 from lib.dex_api import DexAPI
+from lib.dex_version import DexVersionService
 from util.cron import cron
 from util.logger import logger, timed
 
 router = APIRouter()
+dex_version_service = DexVersionService()
 
 
 
@@ -410,3 +412,16 @@ def fix_swap_pairs():
     reset_cache_files()
     time.sleep(10)
     db.SqlUpdate().fix_swap_pairs(trigger="cache_loop")
+
+
+@router.on_event("startup")
+@repeat_every(seconds=86400)
+@timed
+def refresh_dex_version():  # pragma: no cover
+    if memcache.get("testing") is None:
+        try:
+            dex_version_service.refresh()
+        except Exception as e:
+            return default.result(msg=e, loglevel="warning")
+        msg = "dex_version cache refresh complete!"
+        return default.result(msg=msg, loglevel="loop", ignore_until=0)

--- a/api/routes/dex.py
+++ b/api/routes/dex.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+
+from lib.dex_version import DexVersionService
+from models.dex import DexVersionResponse
+from models.generic import ErrorMessage
+
+router = APIRouter()
+service = DexVersionService()
+
+
+@router.post(
+    "/dex_version",
+    description="Latest recommended AtomicDEX GUI version metadata.",
+    response_model=DexVersionResponse,
+    responses={503: {"model": ErrorMessage}},
+    status_code=200,
+)
+def dex_version():
+    info = service.get_version_info()
+    if info is None:
+        err = {"error": "Unable to fetch release metadata"}
+        return JSONResponse(status_code=503, content=err)
+    return info
+

--- a/api/routes/dex.py
+++ b/api/routes/dex.py
@@ -24,3 +24,4 @@ def dex_version():
         return JSONResponse(status_code=503, content=err)
     return info
 
+

--- a/api/routes/prices.py
+++ b/api/routes/prices.py
@@ -15,7 +15,7 @@ cache = Cache()
 
 @router.get(
     "/tickers_v1",
-    description="Returns data cached from https://prices.komodian.info/api/v1/tickers",
+    description="Returns data cached from https://prices.gleec.com/api/v1/tickers",
     responses={406: {"model": ErrorMessage}},
     status_code=200,
 )
@@ -37,7 +37,7 @@ def get_v1_tickers(expire_at: int = 900):
 
 @router.get(
     "/tickers_v2",
-    description="Returns data cached from https://prices.komodian.info/api/v2/tickers",
+    description="Returns data cached from https://prices.gleec.com/api/v2/tickers",
     responses={406: {"model": ErrorMessage}},
     status_code=200,
 )

--- a/api/tests/__init__.py
+++ b/api/tests/__init__.py
@@ -8,5 +8,25 @@ from lib.coins import Coins
 from lib.cache import reset_cache_files
 import util.memcache as memcache
 
+try:  # pragma: no cover - compatibility shim
+    import importlib_metadata
+except ImportError:  # pragma: no cover
+    import importlib.metadata as importlib_metadata
+
+
+def _ensure_entrypoints_get():
+    entry_points_cls = getattr(importlib_metadata, "EntryPoints", None)
+    if entry_points_cls is not None and not hasattr(entry_points_cls, "get"):
+        def _get(self, group, default=None):
+            try:
+                return self.select(group=group)
+            except AttributeError:
+                return default if default is not None else ()
+
+        setattr(entry_points_cls, "get", _get)
+
+
+_ensure_entrypoints_get()
+
 os.environ["IS_TESTING"] = "True"
 reset_cache_files()

--- a/api/tests/test_dex_version.py
+++ b/api/tests/test_dex_version.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+from fastapi.testclient import TestClient
+import pytest
+
+from lib import dex_version as dex_version_lib
+from main import app
+import routes.dex as dex_route
+import util.memcache as memcache
+
+
+class DummyReleaseClient:
+    def __init__(self, tag_name="0.9.3", html_url="https://example.com"):
+        self.tag_name = tag_name
+        self.html_url = html_url
+
+    def get_latest_release(self):
+        return {"tag_name": self.tag_name, "html_url": self.html_url}
+
+
+@pytest.mark.parametrize(
+    "tag,expected_status",
+    [
+        ("0.9.4", "recommended"),
+        ("v0.10.0", "required"),
+        ("1.2", "required"),
+    ],
+)
+def test_refresh_sets_expected_status(monkeypatch, tag, expected_status):
+    captured = {}
+
+    def _set_cache(data):
+        captured["data"] = data
+
+    monkeypatch.setattr(memcache, "set_dex_version", _set_cache)
+    monkeypatch.setattr(memcache, "get_dex_version", lambda: None)
+    service = dex_version_lib.DexVersionService(client=DummyReleaseClient(tag_name=tag))
+
+    payload = service.refresh()
+
+    assert payload is not None
+    assert captured["data"]["data"]["status"] == expected_status
+
+
+def test_get_version_info_returns_cached(monkeypatch):
+    cached = {"data": {"status": "recommended"}}
+    monkeypatch.setattr(memcache, "get_dex_version", lambda: cached)
+    service = dex_version_lib.DexVersionService(client=DummyReleaseClient())
+
+    result = service.get_version_info()
+
+    assert result == cached["data"]
+
+
+def test_dex_version_endpoint_success(monkeypatch):
+    client = TestClient(app)
+    monkeypatch.setattr(
+        dex_route.service,
+        "get_version_info",
+        lambda: {
+            "status": "recommended",
+            "new_version": "0.9.3",
+            "changelog": "https://example.com/changelog",
+            "download_url": "https://example.com",
+        },
+    )
+
+    resp = client.post("/api/v3/dex_version")
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "recommended"
+
+
+def test_dex_version_endpoint_failure(monkeypatch):
+    client = TestClient(app)
+    monkeypatch.setattr(dex_route.service, "get_version_info", lambda: None)
+
+    resp = client.post("/api/v3/dex_version")
+
+    assert resp.status_code == 503

--- a/api/util/memcache.py
+++ b/api/util/memcache.py
@@ -309,6 +309,14 @@ def get_adex_alltime():  # pragma: no cover
     return get("adex_alltime")
 
 
+def set_dex_version(data):  # pragma: no cover
+    update("dex_version_info", data, 86400)
+
+
+def get_dex_version():  # pragma: no cover
+    return get("dex_version_info")
+
+
 # REVIEW CACHE (TOO LARGE)
 # def set_summary(data):  # pragma: no cover
 # update("generic_summary", data, 3600)

--- a/api/util/urls.py
+++ b/api/util/urls.py
@@ -10,7 +10,7 @@ class Urls:
         coins_repo = "https://raw.githubusercontent.com/KomodoPlatform/coins"
         self.coins = f"{coins_repo}/master/coins"
         self.coins_config = f"{coins_repo}/master/utils/coins_config.json"
-        prices_api = "https://prices.komodian.info"
+        prices_api = "https://prices.gleec.com"
         self.prices_tickers_v1 = f"{prices_api}/api/v1/tickers?expire_at=21600"
         self.prices_tickers_v2 = f"{prices_api}/api/v2/tickers?expire_at=21600"
 

--- a/restart_kdf.sh
+++ b/restart_kdf.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# This script is used to restart the Komodo DeFi (kdf) services
+# If not restarted periodically, KDF cpu usage can spike to 100%
+# Add this to cron and run every hour
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "${ROOT_DIR}"
+/usr/bin/docker compose restart komodefi_8762
+


### PR DESCRIPTION
- Updates `prices.komodian.info` -> `prices.gleec.com`
- extends cache keep time
- reduces data update loop freqs
- reduces "pairs_days" from 30 to 14 days (reducing pair combo load for orderbook loop)

The changes above, along with a cronjob to restart kdf hourly, were added to avoid CPU thrashing. KDF orderbook subscription overload could otherwise lead to a cascading failure of orderbook request timeouts. Restarting KDF flushes the subs, while prior data is retained in memcache to avoid lacking data during the restart.

As the KDF orderbook was the main problem, cache timings and loop freqs could be carefully returned closer to earlier values if needed, but I've left these changes in for now for safety.